### PR TITLE
moved types into customTypes file

### DIFF
--- a/respire/src/customTypes.ts
+++ b/respire/src/customTypes.ts
@@ -1,0 +1,5 @@
+// as new states are added, this needs to be extended, i.e. "count"|"songTitle"|...
+export type StateIdentifier = "count"
+export type SetStateMethods = {
+    [Key in StateIdentifier]?: Function;
+};

--- a/respire/src/view.ts
+++ b/respire/src/view.ts
@@ -1,10 +1,5 @@
 import {type ReactNode, useEffect} from "react";
-
-// as new states are added, this needs to be extended, i.e. "count"|"songTitle"|...
-type StateIdentifier = "count"
-type SetStateMethods = {
-    [Key in StateIdentifier]?: Function;
-};
+import {type StateIdentifier, type SetStateMethods} from "./customTypes.ts";
 
 export abstract class View{
     private readonly setStateMethods: SetStateMethods


### PR DESCRIPTION
moved custom types outside of abstract view and into their own file. This means the abstract view doesn't need to be updated every time a new state identifier is introduced and any custom types now have a place to live.